### PR TITLE
Crawl sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "start": "nodemon src/index.js",
     "test": "npx jest",
-    "devtest": "npx jest --watch"
+    "devtest": "npx jest --watch",
+    "crawl": "npx ts-node src/crawl.ts"
   },
   "dependencies": {
     "@types/cheerio": "^0.22.31",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },
-  "name": "gray-beard-seo",
-  "description": "Welcome to your shiny new Codespace running Express! We've got everything fired up and running for you to explore Express.",
+  "name": "ice-scraper",
+  "description": "Web crawler and scraper for sport (associations, leagues, schedules)",
   "version": "1.0.0",
   "main": "src/index.js",
   "author": "d.biagini@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "start": "nodemon src/index.js",
-    "test": "npx jest"
+    "test": "npx jest",
+    "devtest": "npx jest --watch"
   },
   "dependencies": {
     "@types/cheerio": "^0.22.31",

--- a/src/AssociationCrawler.ts
+++ b/src/AssociationCrawler.ts
@@ -21,8 +21,5 @@ export class AssociationCrawler {
     async crawl(start?: number, count?: number) {
         let i = start || 0;
         let last_i = (count ? i + count : this.scrapedTeams.length - 1);
-        while {
-            
-        }
     }
 }

--- a/src/SiteCrawler.ts
+++ b/src/SiteCrawler.ts
@@ -6,15 +6,18 @@ export class SiteCrawler {
     userAgent?: string;
     pageFilter?: string;
     avgDelaySecs?: number;
-    visited: Map<URL, URL[]>;
+    visited!: Map<string, URL[]>;
     cacheExpiry: number = (60 * 60 * 24 * 7);
 
-    constructor(rootPage: string, find: string, ua?: string, filter?: string, delay?: number) {
-        this.rootPage = rootPage;
-        this.visited = new Map<URL, URL[]>;
+    constructor(rootPage: string, ua?: string, filter?: string, delay?: number, cache?: number) {
+        const rootUrl = new URL(rootPage);
+        this.rootPage = rootUrl.href;
+        this.visited = new Map<string, URL[]>;
+        this.userAgent = ua;
 
         if (filter) this.pageFilter = filter;
         if (delay) this.avgDelaySecs = delay;
+        if (cache !== undefined) this.cacheExpiry = cache;
     }
 
     scrapeLinks(page: URL, html: string, max: number = 0): URL[] {
@@ -34,7 +37,7 @@ export class SiteCrawler {
             try {
                 links.push(new URL(href, page.origin));
             } catch (e) {
-                console.log("Error % parsing %", e, page.href);
+                console.log("Error % parsing links on %", e, page.href);
             }
 
         }
@@ -42,15 +45,35 @@ export class SiteCrawler {
     }
 
     async crawl(page: string = this.rootPage) {
+        console.log("crawling %s", page);
         let delay = 0;
         if (this.avgDelaySecs) {
             delay = (this.avgDelaySecs * 2 * Math.random());
         }
 
-        const html = await loadPage(page, this.cacheExpiry, this.userAgent, delay);
-        console.log("parsing %d bytes for  list", html.length);
+        const url = new URL(page);
+        const html = await loadPage(url.href, this.cacheExpiry, this.userAgent, delay);
+        console.log("parsing %d bytes for %s list", html.length, url.href);
 
-        this.scrapeLinks(page, html);
+        const hrefs = this.scrapeLinks(url, html);
+        this.visited.set(url.href, hrefs);
 
+        for (let link of hrefs) {
+            if (!this.visited.has(link.href)) {
+                await this.crawl(link.href);
+            } else {
+                console.log("already crawled %s", link.href);
+            }
+        }
+        console.log("finished crawling %s, found %d links", page, hrefs.length);
+
+    }
+
+    pageCount(): number {
+        return (this.visited.size || 0)
+    }
+
+    getLinks(page: string = this.rootPage): URL[] {
+        return (this.visited.get(page) || []);
     }
 }

--- a/src/SiteCrawler.ts
+++ b/src/SiteCrawler.ts
@@ -63,7 +63,7 @@ export class SiteCrawler {
         return p;
     }
 
-    async crawl(third_parties: boolean,
+    async crawl(origin_filter?: (arg0: URL) => boolean,
                 page: string = this.rootPage, 
                 max_depth: number = this.maxDepth) {
 
@@ -85,16 +85,17 @@ export class SiteCrawler {
         } else {
             for (let link of hrefs.links) {
                 if (!this.visited.has(link.href)) {
-                    if (third_parties || link.origin == url.origin) {
-                        await this.crawl(third_parties, link.href, max_depth - 1);
-                    } else {
-                        console.log("not crawling third party link %s", link.href);
+                    if (link.origin != url.origin) {
+                        if (origin_filter === undefined || !origin_filter(link)) {
+                            console.log("not crawling external link %s", link.href);
+                            continue;
+                        }
                     }
+                    await this.crawl(origin_filter, link.href, max_depth - 1);
                 } else {
                     console.log("already crawled %s", link.href);
                 }
             }
-    
         }
         console.log("finished crawling %s, found %d links", page, hrefs.links.length);
     }

--- a/src/SiteCrawler.ts
+++ b/src/SiteCrawler.ts
@@ -16,7 +16,7 @@ export class SiteCrawler {
     visited!: Map<string, Page>;
     pages: Page[];
     cacheExpiry: number = (60 * 60 * 24 * 7);
-    maxDepth: number = 3;
+    maxDepth: number = 10;
 
     constructor(rootPage: string, 
                 ua?: string, 
@@ -63,7 +63,9 @@ export class SiteCrawler {
         return p;
     }
 
-    async crawl(page: string = this.rootPage, max_depth: number = this.maxDepth) {
+    async crawl(third_parties: boolean,
+                page: string = this.rootPage, 
+                max_depth: number = this.maxDepth) {
 
         console.log("crawling %s, max_depth %d", page, max_depth);
         let delay = 0;
@@ -83,7 +85,11 @@ export class SiteCrawler {
         } else {
             for (let link of hrefs.links) {
                 if (!this.visited.has(link.href)) {
-                    await this.crawl(link.href, max_depth - 1);
+                    if (third_parties || link.origin == url.origin) {
+                        await this.crawl(third_parties, link.href, max_depth - 1);
+                    } else {
+                        console.log("not crawling third party link %s", link.href);
+                    }
                 } else {
                     console.log("already crawled %s", link.href);
                 }

--- a/src/SiteCrawler.ts
+++ b/src/SiteCrawler.ts
@@ -1,6 +1,5 @@
 import cheerio from 'cheerio';
 import { loadPage } from './loader';
-import fs = require('fs');
 
 export type Page = {
     href: string,
@@ -108,10 +107,11 @@ export class SiteCrawler {
 
     // https://javascript.info/json
     toJSON() {
-        return {
+        let o: Object = {
             root: this.rootPage,
             filter: this.pageFilter,
             pages: [Object.fromEntries(this.visited)]
-        }
+        };
+        return o;
     }
 }

--- a/src/SiteCrawler.ts
+++ b/src/SiteCrawler.ts
@@ -1,0 +1,56 @@
+import cheerio from 'cheerio';
+import { loadPage } from './loader';
+
+export class SiteCrawler {
+    rootPage: string;
+    userAgent?: string;
+    pageFilter?: string;
+    avgDelaySecs?: number;
+    visited: Map<URL, URL[]>;
+    cacheExpiry: number = (60 * 60 * 24 * 7);
+
+    constructor(rootPage: string, find: string, ua?: string, filter?: string, delay?: number) {
+        this.rootPage = rootPage;
+        this.visited = new Map<URL, URL[]>;
+
+        if (filter) this.pageFilter = filter;
+        if (delay) this.avgDelaySecs = delay;
+    }
+
+    scrapeLinks(page: URL, html: string, max: number = 0): URL[] {
+        const $ = cheerio.load(html);
+
+        let count = 0;
+        let links: URL[] = [];
+        const anchors = $('a');
+        
+        for (let a of anchors) {
+            if (max && count >= max) {
+                break;
+            }
+
+            const href: string = $(a).attr("href") || "";
+
+            try {
+                links.push(new URL(href, page.origin));
+            } catch (e) {
+                console.log("Error % parsing %", e, page.href);
+            }
+
+        }
+        return links;
+    }
+
+    async crawl(page: string = this.rootPage) {
+        let delay = 0;
+        if (this.avgDelaySecs) {
+            delay = (this.avgDelaySecs * 2 * Math.random());
+        }
+
+        const html = await loadPage(page, this.cacheExpiry, this.userAgent, delay);
+        console.log("parsing %d bytes for  list", html.length);
+
+        this.scrapeLinks(page, html);
+
+    }
+}

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -2,38 +2,85 @@ import minimist from 'minimist';
 import { SiteCrawler } from './SiteCrawler';
 import { urlToFileName } from './loader';
 import fs = require('fs');
+import { writeFile } from 'node:fs/promises';
 
+
+let DEBUG = false;
+let cachMaxAge = (60 * 60 * 24 * 7);
+
+async function crawlUrl(url: string, maxDepth: number, next: Function) {
+    const c = new SiteCrawler(url, undefined, undefined, 10, cachMaxAge, maxDepth);
+
+    c.crawl().then(async () => {
+        try {
+            const outFile = `./output/${urlToFileName(url)}-m${maxDepth}-${Date.now().toString()}.json`;
+            await writeFile(outFile, JSON.stringify(c));
+        } catch (w_error) {
+            console.error("error %s writing site info for %s", w_error, url);
+        }
+    }, (error) => {
+        console.error("error crawling %s", url);
+    }).finally(() => next());
+}
+
+async function runner (urls: string[], maxDepth: number, limit: number) {
+
+    let running = 0;
+    let task = 0;
+
+    const completeCrawl = () => {
+        running --;
+        if (task == urls.length && running == 0) {
+            console.log("finished crawling %d sites", task);
+        }
+    }
+    while (running < limit && urls[task]) {
+        const url = urls[task];
+        console.log("runner sending %s to crawler", url);
+        crawlUrl(url, maxDepth, completeCrawl);
+        running ++;
+        task ++;
+    }
+}
+
+// test 1: npx ts-node src/crawl.ts --url "https://www.abyha.org" --max_depth 4
+// 
 async function main() {
     const argv = minimist(process.argv.slice(1));
 
-    if (argv['url'] === undefined) {
-        console.log("No --url <url> specified");
+    if ((argv['url'] === undefined) && (argv['url_file'] === undefined)) {
+        console.log("No --url <url> or --url_file <file> specified");
         process.exit(0);
     }
-    const startUrl = argv['url'];
+    let urls = [];
+    let thirdPartiesEnabled = (link:URL): boolean => {return false};
+    if (argv['url']) {
+        urls.push(argv['url']);
+        thirdPartiesEnabled = (link: URL): boolean => {
+            if (argv['crawl_third_parties']) {
+                let tp: string = argv['crawl_third_parties'];
+                if (tp.split(",").indexOf(link.origin) >= 0) {
+                    return true;
+                }
+            } 
+            return false;
+        }
+    } else {
+        const data = fs.readFileSync(argv['url_file']);
+        // should be ok for modest size files, but not the most memory efficient approach
+        // fs.readFile(argv['url_file'], (error, data) => {
+        //     if (error) {
+        //         console.error("Error reading url_file %s, %s", argv['url_file'], error);
+        //         return;
+        //     }
+        data.toString().split(/\r?\n/).forEach(line => {
+           urls.push(line);
+        });
+    }
     cachMaxAge = argv['max_age'] ? (argv['max_age']) : (60 * 60 * 24 * 7);
     const maxDepth = argv['max_depth'] ? argv['max_depth'] : 10;
-    const thirdPartiesEnabled = argv['crawl_third_parties'] ? argv['crawl_third_parties'] : false;
-
-    const outFile = argv['out_file'] ? argv['out'] : `./output/${urlToFileName(startUrl)}-m${maxDepth}-${Date.now().toString()}.json`
-    const c = new SiteCrawler(startUrl,
-                              undefined, 
-                              undefined,
-                              10, 
-                              cachMaxAge, 
-                              maxDepth);
-    await c.crawl(thirdPartiesEnabled);
-    const out: string = JSON.stringify(c);
-    console.log(out);
-    try {
-        fs.writeFileSync(outFile, out);
-    } catch (error) {
-        console.log("Error %s writing %d byes to %s", error, out.length, outFile);
-    }
-
+    const limit = argv['threads'] ? argv['threads'] : 10;
+    runner(urls, maxDepth, limit);
 }
-
-let DEBUG = false;
-let cachMaxAge;
 
 main();

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -1,7 +1,38 @@
 import minimist from 'minimist';
 import { SiteCrawler } from './SiteCrawler';
-import { loadPage } from './loader';
+import { urlToFileName } from './loader';
+import fs = require('fs');
 
 async function main() {
+    const argv = minimist(process.argv.slice(1));
+
+    if (argv['url'] === undefined) {
+        console.log("No --url <url> specified");
+        process.exit(0);
+    }
+    const startUrl = argv['url'];
+    cachMaxAge = argv['max_age'] ? (argv['max_age']) : (60 * 60 * 24 * 7);
+    const maxDepth = argv['max_depth'] ? argv['max_depth'] : 10;
+
+    const outFile = argv['out_file'] ? argv['out'] : `./output/${urlToFileName(startUrl)}-m${maxDepth}-${Date.now().toString()}.json`
+    const c = new SiteCrawler(startUrl,
+                              undefined, 
+                              undefined,
+                              10, 
+                              cachMaxAge, 
+                              maxDepth);
+    await c.crawl();
+    const out: string = JSON.stringify(c);
+    console.log(out);
+    try {
+        fs.writeFileSync(outFile, out);
+    } catch (error) {
+        console.log("Error %s writing %d byes to %s", error, out.length, outFile);
+    }
 
 }
+
+let DEBUG = false;
+let cachMaxAge;
+
+main();

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -1,0 +1,7 @@
+import minimist from 'minimist';
+import { SiteCrawler } from './SiteCrawler';
+import { loadPage } from './loader';
+
+async function main() {
+
+}

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -13,6 +13,7 @@ async function main() {
     const startUrl = argv['url'];
     cachMaxAge = argv['max_age'] ? (argv['max_age']) : (60 * 60 * 24 * 7);
     const maxDepth = argv['max_depth'] ? argv['max_depth'] : 10;
+    const thirdPartiesEnabled = argv['crawl_third_parties'] ? argv['crawl_third_parties'] : false;
 
     const outFile = argv['out_file'] ? argv['out'] : `./output/${urlToFileName(startUrl)}-m${maxDepth}-${Date.now().toString()}.json`
     const c = new SiteCrawler(startUrl,
@@ -21,7 +22,7 @@ async function main() {
                               10, 
                               cachMaxAge, 
                               maxDepth);
-    await c.crawl();
+    await c.crawl(thirdPartiesEnabled);
     const out: string = JSON.stringify(c);
     console.log(out);
     try {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -42,8 +42,12 @@ export async function loadPage(url: string, max_age_secs: number = (60 * 60 * 24
     }
 
     if (max_age_secs != 0) {
-        fs.writeFileSync(fileName, response.data);
-        if (DEBUG) console.log("retrieved and cached %d bytes from %s to %s ", response.data.length, url, fileName);
+        try {
+            fs.writeFileSync(fileName, response.data);
+            if (DEBUG) console.log("retrieved and cached %d bytes from %s to %s ", response.data.length, url, fileName);
+        } catch (error) {
+            console.log("Error %s writing %d byes from %s to %s", error, response.data.length, url, fileName);
+        }
     } else {
         if (DEBUG) console.log("retrieved %d bytes from %s", response.data.length, url);
     }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -14,17 +14,12 @@ export function urlToFileName(url: string): string {
     if (!urlAsFileName) {
         throw "Invalid URL for pattern";
     }
-    return (urlAsFileName[1] + urlAsFileName[2].replace("/", "_"));
+    return (urlAsFileName[1] + urlAsFileName[2].replace(/\//g, "_"));
 }
 
 export async function loadPage(url: string, max_age_secs: number = (60 * 60 * 24 * 7), ua: string = edgeUa, delay_net_secs: number = 0) {
-    const urlAsFileName = url.match(/https?\:\/\/([\w\.]+)(\/?[\w\/\.\?=]*)/);
-    if (!urlAsFileName) {
-        throw "Invalid URL for pattern";
-    }
 
-    const deSlashedPath = urlAsFileName[2].replace("/", "_");
-    const fileName = 'page_cache/' + urlAsFileName[1] + deSlashedPath;
+    const fileName = 'page_cache/' + urlToFileName(url);
     const fStat = fs.statSync(fileName, { bigint: false, throwIfNoEntry: false });
 
     if (fStat && (fStat.mtimeMs + (max_age_secs * 1000)) > Date.now()) {
@@ -43,21 +38,29 @@ export async function loadPage(url: string, max_age_secs: number = (60 * 60 * 24
         await sleep(delay_net_secs * 1000);
     }
 
-    const response = await axios.get(url, config);
-    if (response.status != 200) {
-        console.log("response code not 200... ", response.status);
+    let page = "";
+    try {
+        const response = await axios.get(url, config);
+        if (response.status != 200) {
+            console.log("response code not 200... ", response.status);
+        }
+        page = response.data;
+    } catch (error) {
+        console.error("Error retrieving %s: %s", url, error);
     }
 
-    if (max_age_secs != 0) {
+    if (page.length == 0) {
+        return page;
+    } else if (max_age_secs != 0) {
         try {
-            fs.writeFileSync(fileName, response.data);
-            if (DEBUG) console.log("retrieved and cached %d bytes from %s to %s ", response.data.length, url, fileName);
+            fs.writeFileSync(fileName, page);
+            if (DEBUG) console.log("retrieved and cached %d bytes from %s to %s ", page.length, url, fileName);
         } catch (error) {
-            console.log("Error %s writing %d byes from %s to %s", error, response.data.length, url, fileName);
+            console.log("Error %s writing %d byes from %s to %s", error, page.length, url, fileName);
         }
     } else {
-        if (DEBUG) console.log("retrieved %d bytes from %s", response.data.length, url);
+        if (DEBUG) console.log("retrieved %d bytes from %s", page.length, url);
     }
 
-    return (response.data);
+    return (page);
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -9,6 +9,13 @@ function sleep(ms: number) {
       setTimeout(resolve, ms);
     });
 }
+export function urlToFileName(url: string): string {
+    const urlAsFileName = url.match(/https?\:\/\/([\w\.]+)(\/?[\w\/\.\?=]*)/);
+    if (!urlAsFileName) {
+        throw "Invalid URL for pattern";
+    }
+    return (urlAsFileName[1] + urlAsFileName[2].replace("/", "_"));
+}
 
 export async function loadPage(url: string, max_age_secs: number = (60 * 60 * 24 * 7), ua: string = edgeUa, delay_net_secs: number = 0) {
     const urlAsFileName = url.match(/https?\:\/\/([\w\.]+)(\/?[\w\/\.\?=]*)/);

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -10,7 +10,7 @@ function sleep(ms: number) {
     });
 }
 export function urlToFileName(url: string): string {
-    const urlAsFileName = url.match(/https?\:\/\/([\w\.]+)(\/?[\w\/\.\?=]*)/);
+    const urlAsFileName = url.match(/https?\:\/\/([\w\.]+)(\/?[\w\/\.\?=\-]*)/);
     if (!urlAsFileName) {
         throw "Invalid URL for pattern";
     }

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -28,7 +28,7 @@ describe('testing SiteCrawler class', () => {
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl();
+    await a.crawl(true, undefined, undefined);
     expect(a.pageCount()).toBe(7);
     const links = a.getLinks();
 
@@ -63,7 +63,7 @@ describe('testing SiteCrawler class', () => {
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl();
+    await a.crawl(false);
     expect(a.pageCount()).toBe(5);
 
     expect(a.getLinks().length).toBe(3); // 3 links on root
@@ -151,7 +151,7 @@ describe('testing SiteCrawler class', () => {
                               
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl();
+    await a.crawl(false);
     expect(a.pageCount()).toBe(4);
 
     expect(a.getLinks().length).toBe(3); // 3 links on root
@@ -201,6 +201,29 @@ describe('testing SiteCrawler class', () => {
       }]
     }
     expect(JSON.stringify(a)).toBe(JSON.stringify(exp));
+  });
+  test('dont crawl 3rd party anchors', async () => {
+    // Provide the data object to be returned
+    // mockedAxios.get.mockResolvedValue({
+    //   data: snips.assoc_info_html,
+    // });
+    mockedAxios.get.mockResolvedValue({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.assoc_info_html,
+      status: 200,
+    });
+    const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
+    expect(a.pageCount()).toBe(0);
+
+    await a.crawl(false, undefined, undefined);
+    expect(a.pageCount()).toBe(6); // won't crawl hometeamsonline.com link
+    const links = a.getLinks();
+
+    expect(a.getLinks().length).toBe(6);
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
   });
 });
 

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -53,6 +53,10 @@ describe('testing SiteCrawler class', () => {
       status: 200
     })
     .mockResolvedValueOnce({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
       data: snips.html_page_2,
       status: 200
     });
@@ -60,7 +64,7 @@ describe('testing SiteCrawler class', () => {
     expect(a.pageCount()).toBe(0);
 
     await a.crawl();
-    expect(a.pageCount()).toBe(4);
+    expect(a.pageCount()).toBe(5);
 
     expect(a.getLinks().length).toBe(3); // 3 links on root
     expect(a.getLinks()[0].href).toBe("https://www.google.com/page1"); // first link on root is for page 1
@@ -85,12 +89,101 @@ describe('testing SiteCrawler class', () => {
           "href": "https://www.google.com/page1",
           "origin": "https://www.google.com",
           "links": [
+          "https://www.google.com/page1-a",
           "https://www.google.com/page2",
           "https://www.google.com/page3"
           ],
           "title": "Page 1"
       },
-        "https://www.google.com/page2": {
+      "https://www.google.com/page1-a": {
+        "href": "https://www.google.com/page1-a",
+        "origin": "https://www.google.com",
+        "links": [],
+        "title": ""
+    },
+      "https://www.google.com/page2": {
+          "href":"https://www.google.com/page2",
+          "origin": "https://www.google.com",
+          "links":[
+          "https://www.google.com/page1",
+          "https://www.google.com/page3"
+          ],
+          "title":"Page 2"
+      },
+        "https://www.google.com/page3": {
+          "href": "https://www.google.com/page3",
+          "origin": "https://www.google.com",
+          "links": [],
+          "title": ""
+      }
+      }]
+    }
+    expect(JSON.stringify(a)).toBe(JSON.stringify(exp));
+  });
+
+  test('new crawler with max depth 1 layer w/ 3 layers of html anchors', async () => {
+    /* mock the first 2 GETs with HTML including anchors,
+    *  then no anchors.
+    */
+
+    mockedAxios.get.mockResolvedValue({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.html_root_w_3_anchors,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.html_page_1,
+      status: 200
+    })
+    .mockResolvedValueOnce({
+      data: snips.html_page_2,
+      status: 200
+    });
+    const a = new SiteCrawler("https://www.google.com", 
+                              undefined, 
+                              undefined, 
+                              undefined, 
+                              0,
+                              1);
+                              
+    expect(a.pageCount()).toBe(0);
+
+    await a.crawl();
+    expect(a.pageCount()).toBe(4);
+
+    expect(a.getLinks().length).toBe(3); // 3 links on root
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/page1"); // first link on root is for page 1
+    expect(a.getLinks()[1].href).toBe("https://www.google.com/page2"); // second link on root is for page 2
+
+    expect(a.getLinks("https://www.google.com/page1").length).toBe(3); // 2 links on page 2
+
+    let exp = {
+      "root": "https://www.google.com/",
+      "pages": [{
+        "https://www.google.com/":{
+        "href": "https://www.google.com/",
+        "origin": "https://www.google.com",
+        "links": [
+          "https://www.google.com/page1",
+          "https://www.google.com/page2",
+          "https://www.google.com/page3",
+        ],
+        "title":""
+      },
+        "https://www.google.com/page1": {
+          "href": "https://www.google.com/page1",
+          "origin": "https://www.google.com",
+          "links": [
+          "https://www.google.com/page1-a",
+          "https://www.google.com/page2",
+          "https://www.google.com/page3"
+          ],
+          "title": "Page 1"
+      },
+      "https://www.google.com/page2": {
           "href":"https://www.google.com/page2",
           "origin": "https://www.google.com",
           "links":[

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import * as snips from "./html-snips"
+import { SiteCrawler } from '../src/SiteCrawler';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('testing SiteCrawler class', () => {
+  test('new crawler object should result in instance', () => {
+    const a = new SiteCrawler("https://www.google.com");
+    expect(a).toBeInstanceOf(SiteCrawler);
+  });
+
+  test('new crawler with 1 layer of anchors in html content', async () => {
+    // Provide the data object to be returned
+    // mockedAxios.get.mockResolvedValue({
+    //   data: snips.assoc_info_html,
+    // });
+    mockedAxios.get.mockResolvedValue({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.assoc_info_html,
+      status: 200,
+    });
+    const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
+    expect(a.pageCount()).toBe(0);
+
+    await a.crawl();
+    expect(a.pageCount()).toBe(7);
+    const links = a.getLinks();
+
+    expect(a.getLinks().length).toBe(6);
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
+  });
+  test('new crawler with 3 layer of anchors in html content', async () => {
+    // Provide the data object to be returned
+    // mockedAxios.get.mockResolvedValue({
+    //   data: snips.assoc_info_html,
+    // });
+    mockedAxios.get.mockResolvedValue({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.assoc_info_html,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.assoc_no_web_html,
+      status: 200
+    });
+    const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
+    expect(a.pageCount()).toBe(0);
+
+    await a.crawl();
+    expect(a.pageCount()).toBe(9);
+
+    expect(a.getLinks().length).toBe(6);
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
+    expect(a.getLinks("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1").length).toBe(7);
+  });
+});
+

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import * as snips from "./html-snips"
 import { SiteCrawler } from '../src/SiteCrawler';
 
+// https://www.csrhymes.com/2022/03/09/mocking-axios-with-jest-and-typescript.html
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -35,31 +36,78 @@ describe('testing SiteCrawler class', () => {
     expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
   });
   test('new crawler with 3 layer of anchors in html content', async () => {
-    // Provide the data object to be returned
-    // mockedAxios.get.mockResolvedValue({
-    //   data: snips.assoc_info_html,
-    // });
+    /* mock the first 2 GETs with HTML including anchors,
+    *  then no anchors.
+    */
+
     mockedAxios.get.mockResolvedValue({
       data: snips.html_no_a,
       status: 200,
     })
     .mockResolvedValueOnce({
-      data: snips.assoc_info_html,
+      data: snips.html_root_w_3_anchors,
       status: 200,
     })
     .mockResolvedValueOnce({
-      data: snips.assoc_no_web_html,
+      data: snips.html_page_1,
+      status: 200
+    })
+    .mockResolvedValueOnce({
+      data: snips.html_page_2,
       status: 200
     });
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
     await a.crawl();
-    expect(a.pageCount()).toBe(9);
+    expect(a.pageCount()).toBe(4);
 
-    expect(a.getLinks().length).toBe(6);
-    expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
-    expect(a.getLinks("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1").length).toBe(7);
+    expect(a.getLinks().length).toBe(3); // 3 links on root
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/page1"); // first link on root is for page 1
+    expect(a.getLinks()[1].href).toBe("https://www.google.com/page2"); // second link on root is for page 2
+
+    expect(a.getLinks("https://www.google.com/page2").length).toBe(2); // 2 links on page 2
+
+    let exp = {
+      "root": "https://www.google.com/",
+      "pages": [{
+        "https://www.google.com/":{
+        "href": "https://www.google.com/",
+        "origin": "https://www.google.com",
+        "links": [
+          "https://www.google.com/page1",
+          "https://www.google.com/page2",
+          "https://www.google.com/page3",
+        ],
+        "title":""
+      },
+        "https://www.google.com/page1": {
+          "href": "https://www.google.com/page1",
+          "origin": "https://www.google.com",
+          "links": [
+          "https://www.google.com/page2",
+          "https://www.google.com/page3"
+          ],
+          "title": "Page 1"
+      },
+        "https://www.google.com/page2": {
+          "href":"https://www.google.com/page2",
+          "origin": "https://www.google.com",
+          "links":[
+          "https://www.google.com/page1",
+          "https://www.google.com/page3"
+          ],
+          "title":"Page 2"
+      },
+        "https://www.google.com/page3": {
+          "href": "https://www.google.com/page3",
+          "origin": "https://www.google.com",
+          "links": [],
+          "title": ""
+      }
+      }]
+    }
+    expect(JSON.stringify(a)).toBe(JSON.stringify(exp));
   });
 });
 

--- a/test/crawl.test.ts
+++ b/test/crawl.test.ts
@@ -28,7 +28,7 @@ describe('testing SiteCrawler class', () => {
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl(true, undefined, undefined);
+    await a.crawl(() => true, undefined, undefined);
     expect(a.pageCount()).toBe(7);
     const links = a.getLinks();
 
@@ -63,7 +63,7 @@ describe('testing SiteCrawler class', () => {
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl(false);
+    await a.crawl(() => false);
     expect(a.pageCount()).toBe(5);
 
     expect(a.getLinks().length).toBe(3); // 3 links on root
@@ -151,7 +151,7 @@ describe('testing SiteCrawler class', () => {
                               
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl(false);
+    await a.crawl(() => false);
     expect(a.pageCount()).toBe(4);
 
     expect(a.getLinks().length).toBe(3); // 3 links on root
@@ -202,7 +202,7 @@ describe('testing SiteCrawler class', () => {
     }
     expect(JSON.stringify(a)).toBe(JSON.stringify(exp));
   });
-  test('dont crawl 3rd party anchors', async () => {
+  test('dont crawl any 3rd party anchors', async () => {
     // Provide the data object to be returned
     // mockedAxios.get.mockResolvedValue({
     //   data: snips.assoc_info_html,
@@ -218,7 +218,36 @@ describe('testing SiteCrawler class', () => {
     const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
     expect(a.pageCount()).toBe(0);
 
-    await a.crawl(false, undefined, undefined);
+    await a.crawl(() => false, undefined, undefined);
+    expect(a.pageCount()).toBe(6); // won't crawl hometeamsonline.com link
+    const links = a.getLinks();
+
+    expect(a.getLinks().length).toBe(6);
+    expect(a.getLinks()[0].href).toBe("https://www.google.com/contact_request.php?o=a&a=a&n=352&p=1");
+  });
+
+  test('dont crawl \'hometeamsonline.com\' 3rd party anchors', async () => {
+    // Provide the data object to be returned
+    // mockedAxios.get.mockResolvedValue({
+    //   data: snips.assoc_info_html,
+    // });
+    mockedAxios.get.mockResolvedValue({
+      data: snips.html_no_a,
+      status: 200,
+    })
+    .mockResolvedValueOnce({
+      data: snips.assoc_info_html,
+      status: 200,
+    });
+    const a = new SiteCrawler("https://www.google.com", undefined, undefined, undefined, 0);
+    expect(a.pageCount()).toBe(0);
+
+    await a.crawl((link: URL) => {
+      if (link.origin == 'https://www.hometeamsonline.com') {
+        return false;
+      }
+      return true;
+    }, undefined, undefined);
     expect(a.pageCount()).toBe(6); // won't crawl hometeamsonline.com link
     const links = a.getLinks();
 

--- a/test/html-snips.ts
+++ b/test/html-snips.ts
@@ -261,3 +261,39 @@ export const html_no_a = `
 </head>
 </html>
 `
+
+export const html_root_w_3_anchors = `
+<!DOCTYPE html>
+<html lang = "en">
+  <div class="itsADiv">
+    <head>Root Awesomeness</head>
+    <h1>so cool</h1>
+    <a href="/page1">Root page link to Page 1</a>
+    <a href="/page2">Root page link to Page 2</a>
+    <a href="/page3">Root page link to Page 3</a>
+  </div>
+</html>
+`
+export const html_page_1 = `
+<!DOCTYPE html>
+<html lang = "en">
+  <div class="itsADiv">
+    <head><title>Page 1</title></head>
+    <h1>so cool</h1>
+    <a href="/page2">Page 1 link to Page 2</a>
+    <a href="/page3">Page 1 link to Page 3</a>
+  </div>
+</html>
+`
+
+export const html_page_2 = `
+<!DOCTYPE html>
+<html lang = "en">
+    <head><title>Page 2</title></head>
+    <div class="itsADiv">
+    <h1>so cool</h1>
+    <a href="/page1">Page 2 link to Page 1</a>
+    <a href="/page3">Page 2 link to Page 3</a>
+  </div>
+</html>
+`

--- a/test/html-snips.ts
+++ b/test/html-snips.ts
@@ -280,6 +280,7 @@ export const html_page_1 = `
   <div class="itsADiv">
     <head><title>Page 1</title></head>
     <h1>so cool</h1>
+    <a href="/page1-a">Page 1 link to Page 1 sub A</a>
     <a href="/page2">Page 1 link to Page 2</a>
     <a href="/page3">Page 1 link to Page 3</a>
   </div>

--- a/test/html-snips.ts
+++ b/test/html-snips.ts
@@ -19,7 +19,8 @@ export const assoc_info_html = `<html><div class="desc-container-table">
     </tr>
     <tr>
         <th>Website</th>
-        <td id="assoc-web"><a href="https://www.hometeamsonline.com/teams/?u=alaskaallstars&amp;s=hockey" title="https://www.hometeamsonline.com/teams/?u=alaskaallstars&amp;s=hockey" target="_blank">https://www.hometeamsonline.com/teams/?u=alaskaallstars&s=hockey</a> <a href="website_request.php?o=a&n=352"><img class="info-add-button" alt="Edit association Website" title="Edit Association Website" src="/images/curved-arrow-yellow-right.png"></a></td>
+        
+        <td id="assoc-web"><a href="https://www.hometeamsonline.com/teams/1?u=alaskaallstars&amp;s=hockey" title="https://www.hometeamsonline.com/teams/?u=alaskaallstars&amp;s=hockey" target="_blank">https://www.hometeamsonline.com/teams/?u=alaskaallstars&s=hockey</a> <a href="website_request.php?o=a&n=352"><img class="info-add-button" alt="Edit association Website" title="Edit Association Website" src="/images/curved-arrow-yellow-right.png"></a></td>
         <th>Hockey Director</th>
         <td id="assoc-director"><a href="contact_request.php?o=a&a=a&n=352&p=4"><img class="info-add-button" alt="Add association Contact" title="Add Team Contact" src="/images/curved-arrow-green-right.png"></a></td>
     </tr>
@@ -212,7 +213,9 @@ export const assoc_no_web_html = `<html><div class="desc-container-table">
         </td>
     </tr>
 </table>
-</div></html>`;
+</div>
+<a href="/testing">Tests are nice</a>
+</html>`;
 
 export const html_one_row = `
 <!DOCTYPE html>
@@ -249,3 +252,12 @@ export const html_one_row = `
             </div>
 
 `;
+
+export const html_no_a = `
+<!DOCTYPE html>
+<html lang = "en">
+<head>
+<div class="profile-upd-del">
+</head>
+</html>
+`

--- a/test/scrape.test.ts
+++ b/test/scrape.test.ts
@@ -21,7 +21,7 @@ describe('testing Association class', () => {
     expect(a.scrapedTeams.length).toBe(3);
     expect(a.scrapedTeams[2]!.name).toBe("Fairbanks Arctic Lions");
     expect(a.scrapedTeams[2]!.rinks).toBe("Dempsey Anderson Ice Arenas (Anchorage, AK)");
-    expect(a.scrapedTeams[2]!.assoc_web).toBe("https://www.hometeamsonline.com/teams/?u=alaskaallstars&s=hockey")
+    expect(a.scrapedTeams[2]!.assoc_web).toBe("https://www.hometeamsonline.com/teams/1?u=alaskaallstars&s=hockey")
   });
 
   test('Assoc scrape with no rinks', async () => {

--- a/test/site_list.txt
+++ b/test/site_list.txt
@@ -1,0 +1,3 @@
+https://www.google.com 
+https://www.yahoo.com
+


### PR DESCRIPTION
async / limited parallel crawler for list of sites.  Supports a origin filter mechanism to allow traversing off original domain, but defaults to 1st party links only.

_example_
npx ts-node --url_file test/site_list.txt 